### PR TITLE
Add collapsible hierarchy tree

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -65,8 +65,8 @@ function createHierarchyNode(node, depth, expandedNodes, onToggleNode) {
   );
 
   const header = createElement('div', { className: 'hierarchy-node-header' }, [
-    createElement('span', { className: 'hierarchy-node-label' }, node.label),
-    toggleButton
+    toggleButton,
+    createElement('span', { className: 'hierarchy-node-label' }, node.label)
   ]);
 
   const children =
@@ -84,24 +84,26 @@ function createHierarchyNode(node, depth, expandedNodes, onToggleNode) {
     'div',
     {
       className: 'hierarchy-node',
-      style: { marginLeft: `${depth * 16}px` }
+      style: { marginLeft: `${depth * 12}px` }
     },
     [header, children]
   );
 }
 
 function createHierarchyContent(statusMessage, expandedNodes, onToggleNode) {
-  const content = createElement('main', { className: 'content-area' });
-  const card = createElement('section', { className: 'content-card hierarchy-card' }, [
-    createElement('h1', {}, PAGES.hierarchy.title),
+  const content = createElement('main', {
+    className: 'content-area hierarchy-content'
+  });
+  content.appendChild(
     createElement('div', { className: 'hierarchy-tree' }, [
       createHierarchyNode(HIERARCHY_DATA, 0, expandedNodes, onToggleNode)
-    ]),
-    statusMessage
-      ? createElement('p', { className: 'status-message' }, statusMessage)
-      : null
-  ]);
-  content.appendChild(card);
+    ])
+  );
+  if (statusMessage) {
+    content.appendChild(
+      createElement('p', { className: 'status-message hierarchy-status' }, statusMessage)
+    );
+  }
   return content;
 }
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -16,6 +16,16 @@ const PAGES = {
   }
 };
 
+const HIERARCHY_DATA = {
+  id: 'life',
+  label: 'Life',
+  children: [
+    { id: 'bacteria', label: 'Bacteria', children: [] },
+    { id: 'archaea', label: 'Archaea', children: [] },
+    { id: 'eukarya', label: 'Eukarya', children: [] }
+  ]
+};
+
 const BUTTONS = [
   { key: 'hierarchy', label: 'Hierarchy', icon: hierarchyIcon },
   { key: 'checklist', label: 'Checklist', icon: checklistIcon },
@@ -26,7 +36,80 @@ function createTopBar() {
   return createElement('header', { className: 'top-bar' }, 'Livsverket');
 }
 
-function createContent(activePage, statusMessage) {
+function createHierarchyNode(node, depth, expandedNodes, onToggleNode) {
+  const hasChildren = node.children.length > 0;
+  const isExpanded = expandedNodes[node.id] ?? (depth === 0);
+  const toggleClasses = ['node-toggle'];
+  if (!hasChildren) {
+    toggleClasses.push('node-toggle--inactive');
+  }
+
+  const toggleButton = createElement(
+    'button',
+    {
+      className: toggleClasses.join(' '),
+      onClick: (event) => {
+        event.stopPropagation();
+        if (!hasChildren) {
+          return;
+        }
+        onToggleNode(node.id);
+      },
+      attrs: {
+        'aria-label': `${isExpanded ? 'Collapse' : 'Expand'} ${node.label}`,
+        'aria-expanded': hasChildren ? (isExpanded ? 'true' : 'false') : 'false',
+        'aria-disabled': hasChildren ? 'false' : 'true'
+      }
+    },
+    hasChildren && isExpanded ? '−' : '+'
+  );
+
+  const header = createElement('div', { className: 'hierarchy-node-header' }, [
+    createElement('span', { className: 'hierarchy-node-label' }, node.label),
+    toggleButton
+  ]);
+
+  const children =
+    isExpanded && node.children.length > 0
+      ? createElement(
+          'div',
+          { className: 'hierarchy-children' },
+          node.children.map((child) =>
+            createHierarchyNode(child, depth + 1, expandedNodes, onToggleNode)
+          )
+        )
+      : null;
+
+  return createElement(
+    'div',
+    {
+      className: 'hierarchy-node',
+      style: { marginLeft: `${depth * 16}px` }
+    },
+    [header, children]
+  );
+}
+
+function createHierarchyContent(statusMessage, expandedNodes, onToggleNode) {
+  const content = createElement('main', { className: 'content-area' });
+  const card = createElement('section', { className: 'content-card hierarchy-card' }, [
+    createElement('h1', {}, PAGES.hierarchy.title),
+    createElement('div', { className: 'hierarchy-tree' }, [
+      createHierarchyNode(HIERARCHY_DATA, 0, expandedNodes, onToggleNode)
+    ]),
+    statusMessage
+      ? createElement('p', { className: 'status-message' }, statusMessage)
+      : null
+  ]);
+  content.appendChild(card);
+  return content;
+}
+
+function createContent(activePage, statusMessage, expandedNodes, onToggleNode) {
+  if (activePage === 'hierarchy') {
+    return createHierarchyContent(statusMessage, expandedNodes, onToggleNode);
+  }
+
   const { title, description } = PAGES[activePage];
   const content = createElement('main', { className: 'content-area' });
   const card = createElement('section', { className: 'content-card' }, [
@@ -79,14 +162,22 @@ async function fetchStatus() {
 function App() {
   const [activePage, setActivePage] = useState('hierarchy');
   const [status, setStatus] = useState('Connecting to backend...');
+  const [expandedNodes, setExpandedNodes] = useState(() => ({ life: true }));
 
   if (status === 'Connecting to backend...') {
     fetchStatus().then(setStatus);
   }
 
+  const toggleNode = (nodeId) => {
+    setExpandedNodes((prev) => ({
+      ...prev,
+      [nodeId]: !prev[nodeId]
+    }));
+  };
+
   const shell = createElement('div', { className: 'app-shell' });
   shell.appendChild(createTopBar());
-  shell.appendChild(createContent(activePage, status));
+  shell.appendChild(createContent(activePage, status, expandedNodes, toggleNode));
   shell.appendChild(createBottomNav(activePage, setActivePage));
   return shell;
 }

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -167,3 +167,85 @@ button {
   width: 1.75rem;
   height: 1.75rem;
 }
+
+.hierarchy-card {
+  text-align: left;
+}
+
+.hierarchy-tree {
+  margin-top: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.hierarchy-node {
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(56, 189, 248, 0.18);
+  border-radius: 14px;
+  padding: 0.95rem 1rem;
+  box-shadow: 0 16px 32px rgba(2, 6, 23, 0.55);
+  transition: border-color 150ms ease-out, background 150ms ease-out;
+}
+
+.hierarchy-node:hover {
+  border-color: rgba(56, 189, 248, 0.32);
+  background: rgba(15, 23, 42, 0.95);
+}
+
+.hierarchy-node-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.hierarchy-node-label {
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.node-toggle {
+  width: 2.1rem;
+  height: 2.1rem;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.14);
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  color: #38bdf8;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  font-weight: 600;
+  line-height: 1;
+  transition: background 150ms ease-out, transform 150ms ease-out;
+}
+
+.node-toggle:hover {
+  background: rgba(56, 189, 248, 0.25);
+}
+
+.node-toggle:active {
+  transform: scale(0.95);
+}
+
+.node-toggle--inactive {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.node-toggle--inactive:hover {
+  background: rgba(56, 189, 248, 0.14);
+}
+
+.hierarchy-children {
+  margin-top: 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.hierarchy-card .status-message {
+  margin-top: 1.5rem;
+}

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -168,47 +168,51 @@ button {
   height: 1.75rem;
 }
 
-.hierarchy-card {
-  text-align: left;
+.hierarchy-content {
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
+  gap: 1rem;
 }
 
 .hierarchy-tree {
-  margin-top: 1.2rem;
   display: flex;
   flex-direction: column;
-  gap: 0.9rem;
+  gap: 0.65rem;
+  width: 100%;
+  max-width: 420px;
+  align-self: center;
 }
 
 .hierarchy-node {
-  background: rgba(15, 23, 42, 0.85);
+  background: rgba(15, 23, 42, 0.82);
   border: 1px solid rgba(56, 189, 248, 0.18);
-  border-radius: 14px;
-  padding: 0.95rem 1rem;
-  box-shadow: 0 16px 32px rgba(2, 6, 23, 0.55);
+  border-radius: 10px;
+  padding: 0.7rem 0.85rem;
+  box-shadow: 0 12px 24px rgba(2, 6, 23, 0.45);
   transition: border-color 150ms ease-out, background 150ms ease-out;
 }
 
 .hierarchy-node:hover {
   border-color: rgba(56, 189, 248, 0.32);
-  background: rgba(15, 23, 42, 0.95);
+  background: rgba(15, 23, 42, 0.92);
 }
 
 .hierarchy-node-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
+  gap: 0.6rem;
 }
 
 .hierarchy-node-label {
-  font-size: 1.05rem;
+  font-size: 0.95rem;
   font-weight: 600;
-  letter-spacing: 0.03em;
+  letter-spacing: 0.02em;
 }
 
 .node-toggle {
-  width: 2.1rem;
-  height: 2.1rem;
+  width: 1.6rem;
+  height: 1.6rem;
   border-radius: 999px;
   background: rgba(56, 189, 248, 0.14);
   border: 1px solid rgba(56, 189, 248, 0.3);
@@ -216,7 +220,7 @@ button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.1rem;
+  font-size: 0.95rem;
   font-weight: 600;
   line-height: 1;
   transition: background 150ms ease-out, transform 150ms ease-out;
@@ -240,12 +244,12 @@ button {
 }
 
 .hierarchy-children {
-  margin-top: 0.85rem;
+  margin-top: 0.6rem;
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
+  gap: 0.6rem;
 }
 
-.hierarchy-card .status-message {
-  margin-top: 1.5rem;
+.hierarchy-status {
+  margin: 0.5rem 0 0;
 }


### PR DESCRIPTION
## Summary
- render the Hierarchy page as a collapsible tree with a Life root node and child domains
- track expansion state so the Life node loads expanded and children can be toggled in the future
- style hierarchy cards, nested nodes, and toggle buttons for an indented tree presentation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d01250957883329be337e424b2001c