### PR TITLE
Update footer navigation icons and clean backend status message

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Livsverket</title>
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,400,0,0"
+    />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>

--- a/frontend/src/icons.js
+++ b/frontend/src/icons.js
@@ -1,34 +1,24 @@
 import { createElement } from './mini-react.js';
 
-function createSvg(pathD) {
+function createMaterialIcon(name) {
   return createElement(
-    'svg',
+    'span',
     {
-      className: 'icon',
-      attrs: {
-        viewBox: '0 0 24 24',
-        xmlns: 'http://www.w3.org/2000/svg',
-        'aria-hidden': 'true'
-      }
+      className: 'material-symbols-rounded',
+      attrs: { 'aria-hidden': 'true' }
     },
-    createElement('path', { attrs: { d: pathD, fill: 'currentColor', 'fill-rule': 'evenodd', 'clip-rule': 'evenodd' } })
+    name
   );
 }
 
 export function hierarchyIcon() {
-  return createSvg(
-    'M5 6a3 3 0 0 1 3-3h0a3 3 0 0 1 3 3v1.586A2 2 0 0 1 12 9h2a2 2 0 0 1 1.414.586L16 10.172 17.586 8.586A2 2 0 0 1 19 8h0a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h0a2 2 0 0 1-1.414-.586L16 13.828l-1.586 1.586A2 2 0 0 1 13 16h-1v2a3 3 0 0 1-3 3h0a3 3 0 0 1-3-3v-1.17a3 3 0 0 1-1.803-.884l-.143-.152A3 3 0 0 1 3 14v-1a3 3 0 0 1 .803-2.048l.143-.152A3 3 0 0 1 5 9.17z'
-  );
+  return createMaterialIcon('cruelty_free');
 }
 
 export function checklistIcon() {
-  return createSvg(
-    'M7 4a3 3 0 0 1 3-3h8a3 3 0 0 1 3 3v16a2 2 0 0 1-2 2H10a3 3 0 0 1-3-3zm3.75 4.75a.75.75 0 0 0-1.5 0v.5a.75.75 0 0 0 1.5 0zm0 5a.75.75 0 0 0-1.5 0v.5a.75.75 0 0 0 1.5 0zm3-3.25a.75.75 0 0 1 0-1.5H16a.75.75 0 0 1 0 1.5zm0 5a.75.75 0 0 1 0-1.5H16a.75.75 0 0 1 0 1.5zM5 7.5A2.5 2.5 0 0 0 2.5 10v6A2.5 2.5 0 0 0 5 18.5H7A2.5 2.5 0 0 0 9.5 16v-6A2.5 2.5 0 0 0 7 7.5z'
-  );
+  return createMaterialIcon('checklist');
 }
 
 export function settingsIcon() {
-  return createSvg(
-    'M12 8.25a3.75 3.75 0 1 0 0 7.5 3.75 3.75 0 0 0 0-7.5m-8.835 3.53a1.5 1.5 0 0 1 0-1.56l.77-1.335a1.5 1.5 0 0 1 1.221-.75l1.058-.07a.75.75 0 0 0 .654-.48l.384-.98a1.5 1.5 0 0 1 1.098-.918l1.517-.304a1.5 1.5 0 0 1 1.02.132l.915.457a.75.75 0 0 0 .674 0l.915-.457a1.5 1.5 0 0 1 1.02-.132l1.517.304a1.5 1.5 0 0 1 1.098.918l.384.98a.75.75 0 0 0 .654.48l1.058.07a1.5 1.5 0 0 1 1.221.75l.77 1.335a1.5 1.5 0 0 1 0 1.56l-.77 1.335a1.5 1.5 0 0 1-1.221.75l-1.058.07a.75.75 0 0 0-.654.48l-.384.98a1.5 1.5 0 0 1-1.098.918l-1.517.304a1.5 1.5 0 0 1-1.02-.132l-.915-.457a.75.75 0 0 0-.674 0l-.915.457a1.5 1.5 0 0 1-1.02.132l-1.517-.304a1.5 1.5 0 0 1-1.098-.918l-.384-.98a.75.75 0 0 0-.654-.48l-1.058-.07a1.5 1.5 0 0 1-1.221-.75z'
-  );
+  return createMaterialIcon('settings');
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -128,11 +128,15 @@ function createContent(activePage, statusMessage, expandedNodes, onToggleNode) {
 function createNavButton(button, isActive, onSelect) {
   const icon = button.icon();
   icon.classList.add('nav-icon');
-  const label = createElement('span', {}, button.label);
-  const buttonElement = createElement('button', { className: 'nav-button', onClick: () => onSelect(button.key) }, [
-    icon,
-    label
-  ]);
+  const buttonElement = createElement(
+    'button',
+    {
+      className: 'nav-button',
+      onClick: () => onSelect(button.key),
+      attrs: { 'aria-label': button.label }
+    },
+    icon
+  );
   if (isActive) {
     buttonElement.classList.add('active');
   }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -158,7 +158,8 @@ async function fetchStatus() {
       throw new Error('Request failed');
     }
     const data = await response.json();
-    return data.message;
+    const message = typeof data.message === 'string' ? data.message.trim() : '';
+    return message === 'Backend is running' ? '' : message;
   } catch (error) {
     console.warn('Unable to reach backend:', error.message);
     return 'Backend connection unavailable';

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -94,26 +94,11 @@ button {
 
 .nav-button {
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0.45rem;
   color: rgba(203, 213, 225, 0.8);
   transition: color 150ms ease-out, background 150ms ease-out, transform 150ms ease-out;
   position: relative;
-}
-
-.nav-button svg {
-  width: 1.8rem;
-  height: 1.8rem;
-  display: block;
-  fill: currentColor;
-}
-
-.nav-button span {
-  font-size: 0.68rem;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
 }
 
 .nav-button.active {
@@ -132,6 +117,19 @@ button {
 
 .nav-button:active {
   transform: translateY(1px);
+}
+
+.nav-icon {
+  font-size: 2rem;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: inherit;
+}
+
+.material-symbols-rounded {
+  font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 40;
 }
 
 @media (min-width: 640px) {
@@ -159,14 +157,6 @@ button {
   color: rgba(148, 163, 184, 0.85);
 }
 
-.nav-icon {
-  color: inherit;
-}
-
-.icon {
-  width: 1.75rem;
-  height: 1.75rem;
-}
 
 .hierarchy-content {
   flex-direction: column;

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func statusHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(statusResponse{Message: "Backend is running"})
+	json.NewEncoder(w).Encode(statusResponse{Message: ""})
 }
 
 func handlePreflight(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- load the Material Symbols font and swap the footer navigation to use the Cruelty Free, Checklist, and Settings icons
- remove the navigation button labels and restyle the footer for the new icon-only layout
- clear the backend status response so the "Backend is running" text is no longer shown

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d048676ec48332bb9fcc829af232da